### PR TITLE
Add skipLanguages Input/Output

### DIFF
--- a/.github/workflows/codeql-analysis-w-build-command.yml
+++ b/.github/workflows/codeql-analysis-w-build-command.yml
@@ -61,8 +61,12 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - if: matrix.build-mode == 'manual'
-      shell: bash
-      run: ${{ matrix.manual-build-command }}
+      name: Build and Analysis
+      run: |
+        echo '${{ toJSON(matrix.manual-build-command) }}' | jq -r '.[]' | while read LINE; do
+          echo "Running command: $LINE"
+          eval $LINE
+        done
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Various inputs are defined in [`action.yml`](action.yml):
 | envvars_js | Env vars in a JSON format with the variables that should be used for build | {} | 
 | envvars_python | Env vars in a JSON format with the variables that should be used for build | {} | 
 | envvars_ruby | Env vars in a JSON format with the variables that should be used for build | {} | 
-| envvars_swift | Env vars in a JSON format with the variables that should be used for build | {} | 
+| envvars_swift | Env vars in a JSON format with the variables that should be used for build | {} |
+| skip_languages | The languages to skip when building the languages map. Useful if the test for a specific language is running on another tool | [] |
 
 ## ⬅️ Outputs
 | Name | Description |
@@ -108,6 +109,7 @@ Various inputs are defined in [`action.yml`](action.yml):
 | languages_codeql | The languages of the repository as an array for CodeQL Matrix without Build Mode set |
 | languages_codeql_w_buildmode | The languages of the repository as a JSON array ([{language: string, build-mode: string, manual-build-command: [], vpn-connection: boolean, pre-commands: [], env-vars: {}}]) for CodeQL Matrix with Build Mode set |
 | codeql_supported | Bool that indicates if there are supported languages by CodeQL |
+| skip_languages | The languages that were skipped when building the languages map
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Various inputs are defined in [`action.yml`](action.yml):
 | envvars_python | Env vars in a JSON format with the variables that should be used for build | {} | 
 | envvars_ruby | Env vars in a JSON format with the variables that should be used for build | {} | 
 | envvars_swift | Env vars in a JSON format with the variables that should be used for build | {} |
-| skip_languages | The languages to skip when building the languages map. Useful if the test for a specific language is running on another tool | [] |
+| skip_languages | The languages to skip when building the languages map, comma separated list. Useful if the test for a specific language is running on another tool | none |
 
 ## ⬅️ Outputs
 | Name | Description |

--- a/action.yml
+++ b/action.yml
@@ -155,9 +155,8 @@ inputs:
     description: The environment variables to set before building swift projects
     required: false
   skip_languages:
-    description: The languages to skip when building the languages map
+    description: The languages to skip when building the languages map, comma separated list
     required: false
-    type: array
 
 outputs:
   languages_repo:

--- a/action.yml
+++ b/action.yml
@@ -154,6 +154,10 @@ inputs:
   envvars_swift:
     description: The environment variables to set before building swift projects
     required: false
+  skip_languages:
+    description: The languages to skip when building the languages map
+    required: false
+    type: array
 
 outputs:
   languages_repo:
@@ -164,6 +168,8 @@ outputs:
     description: The languages of the repository with CodeQL support as a JSON array, already formatted in the name that is identified by codeql and the build mode
   codeql_supported:
     description: Bool that indicates if there are supported languages by CodeQL 
+  skip_languages:
+    description: The languages that were skipped when building the languages map
 
 runs:
   using: "node20"

--- a/dist/index.js
+++ b/dist/index.js
@@ -30008,15 +30008,25 @@ async function run() {
         };
         // If there is an input for the module passing a custom build mode, store on this transitive const
         const customBuildmode = {
-            "c-cpp": core.getInput('buildmode_cpp'),
-            "csharp": core.getInput('buildmode_csharp'),
-            "go": core.getInput('buildmode_go'),
-            "java-kotlin": core.getInput('buildmode_javakotlin'),
-            "javascript-typescript": core.getInput('buildmode_js'),
-            "python": core.getInput('buildmode_python'),
-            "ruby": core.getInput('buildmode_ruby'),
-            "swift": core.getInput('buildmode_swift'),
+            "c-cpp": core.getInput('buildmode_cpp').toLowerCase(),
+            "csharp": core.getInput('buildmode_csharp').toLowerCase(),
+            "go": core.getInput('buildmode_go').toLowerCase(),
+            "java-kotlin": core.getInput('buildmode_javakotlin').toLowerCase(),
+            "javascript-typescript": core.getInput('buildmode_js').toLowerCase(),
+            "python": core.getInput('buildmode_python').toLowerCase(),
+            "ruby": core.getInput('buildmode_ruby').toLowerCase(),
+            "swift": core.getInput('buildmode_swift').toLowerCase(),
         };
+        // Languages that should be skipped from the analysis (useful for when a test is running in another tool)
+        const skipLanguages = core.getInput('skip_languages') ? core.getInput('skip_languages').split(',').map(lang => lang.trim().toLowerCase()) : [];
+        // Check if skipLanguages has valid values
+        if (skipLanguages.length > 0) {
+            for (const lang of skipLanguages) {
+                if (!Object.keys(codeqlBuildmodeMapping).includes(lang)) {
+                    throw new Error(`Invalid language ${lang} in skip_languages input. Valid languages are ${Object.keys(codeqlLanguageMapping).join(', ')}`);
+                }
+            }
+        }
         // If there is a custom build mode, update the default build mode mapping
         for (const language in customBuildmode) {
             if (customBuildmode[language]) {
@@ -30069,7 +30079,9 @@ async function run() {
         const langResponse = await octokit.request(`GET /repos/${owner}/${repo}/languages`);
         core.debug(JSON.stringify({ langResponse }));
         let languages = Object.keys(langResponse.data);
-        let languages_codeql_format = Array.from(new Set(languages.map(l => codeqlLanguageMapping[l.toLowerCase()]).filter(l => l)));
+        let languages_codeql_format = Array.from(new Set(languages
+            .map(l => codeqlLanguageMapping[l.toLowerCase()])
+            .filter(l => l && !skipLanguages.includes(l))));
         let languages_codeql_output = languages_codeql_format.map(language => ({
             language: language,
             "build-mode": codeqlBuildmodeMapping[language],
@@ -30082,6 +30094,7 @@ async function run() {
         core.setOutput('languages_codeql', JSON.stringify(languages_codeql_format));
         core.setOutput('languages_codeql_w_buildmode', JSON.stringify(languages_codeql_output));
         core.setOutput('codeql_supported', JSON.stringify(languages_codeql_format.length > 0));
+        core.setOutput('skip_languages', JSON.stringify(skipLanguages));
     }
     catch (error) {
         // Fail the workflow run if an error occurs

--- a/src/run.ts
+++ b/src/run.ts
@@ -56,19 +56,22 @@ export async function run(): Promise<void> {
 
     // If there is an input for the module passing a custom build mode, store on this transitive const
     const customBuildmode : { [key: string]: string } = {
-      "c-cpp": core.getInput('buildmode_cpp'),
-      "csharp": core.getInput('buildmode_csharp'),
-      "go": core.getInput('buildmode_go'),
-      "java-kotlin": core.getInput('buildmode_javakotlin'),
-      "javascript-typescript": core.getInput('buildmode_js'),
-      "python": core.getInput('buildmode_python'),
-      "ruby": core.getInput('buildmode_ruby'),
-      "swift": core.getInput('buildmode_swift'),
+      "c-cpp": core.getInput('buildmode_cpp').toLowerCase(),
+      "csharp": core.getInput('buildmode_csharp').toLowerCase(),
+      "go": core.getInput('buildmode_go').toLowerCase(),
+      "java-kotlin": core.getInput('buildmode_javakotlin').toLowerCase(),
+      "javascript-typescript": core.getInput('buildmode_js').toLowerCase(),
+      "python": core.getInput('buildmode_python').toLowerCase(),
+      "ruby": core.getInput('buildmode_ruby').toLowerCase(),
+      "swift": core.getInput('buildmode_swift').toLowerCase(),
     }
+
+    // Languages that should be skipped from the analysis (useful for when a test is running in another tool)
+    const skipLanguages : string[] = core.getInput('skip_languages') ? core.getInput('skip_languages').split(',').map(lang => lang.trim().toLowerCase()) : []
 
     // If there is a custom build mode, update the default build mode mapping
     for (const language in customBuildmode) {
-      if (customBuildmode[language]) {
+      if (customBuildmode[language] && !skipLanguages.includes(language)) {
         codeqlBuildmodeMapping[language] = customBuildmode[language]
       }
     }


### PR DESCRIPTION
- Add a new Input SkipLanguages to skip a list of languages from creating the Matrix on Action
- Add a new output with all SkipLanguages that are set
- Make de buildMode input more reliable, making it lowercase when getting the value for the first time