### PR TITLE
Define SetupLanguage to be on output matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ Various inputs are defined in [`action.yml`](action.yml):
 | github&#x2011;token | Token to use to authorize. | ${{&nbsp;github.token&nbsp;}} |
 | owner | The repository owner | ${{ github.repository_owner }} |
 | repo | The repository name | ${{ github.event.repository.name }} |
-| buildvpn_cpp | Indicates if a VPN Connection needs to be established for C++ | none |
-| buildvpn_csharp | Indicates if a VPN Connection needs to be established for C# | none |
-| buildvpn_go | Indicates if a VPN Connection needs to be established for Go | none |
-| buildvpn_javakotlin | Indicates if a VPN Connection needs to be established for Java/Kotlin | none |
-| buildvpn_js | Indicates if a VPN Connection needs to be established for JavaScript/TypeScript | none |
-| buildvpn_python | Indicates if a VPN Connection needs to be established for Python | none |
-| buildvpn_ruby | Indicates if a VPN Connection needs to be established for Ruby | none |
-| buildvpn_swift | Indicates if a VPN Connection needs to be established for Swift | none |
+| buildvpn_cpp | Indicates if a VPN Connection needs to be established for C++ | false |
+| buildvpn_csharp | Indicates if a VPN Connection needs to be established for C# | false |
+| buildvpn_go | Indicates if a VPN Connection needs to be established for Go | false |
+| buildvpn_javakotlin | Indicates if a VPN Connection needs to be established for Java/Kotlin | false |
+| buildvpn_js | Indicates if a VPN Connection needs to be established for JavaScript/TypeScript | false |
+| buildvpn_python | Indicates if a VPN Connection needs to be established for Python | false |
+| buildvpn_ruby | Indicates if a VPN Connection needs to be established for Ruby | false |
+| buildvpn_swift | Indicates if a VPN Connection needs to be established for Swift | false |
 | buildmode_cpp | Custom build mode for C++ | none |
 | buildmode_csharp | Custom build mode for C# | none |
 | buildmode_go | Custom build mode for Go | none |
@@ -101,14 +101,14 @@ Various inputs are defined in [`action.yml`](action.yml):
 | envvars_ruby | Env vars in a JSON format with the variables that should be used for build | {} | 
 | envvars_swift | Env vars in a JSON format with the variables that should be used for build | {} |
 | skip_languages | The languages to skip when building the languages map, comma separated list. Useful if the test for a specific language is running on another tool | none |
-| buildsetup_cpp | Indicates if the build for CPP projects needs to have any specific setup for CPP. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
-| buildsetup_csharp | Indicates if the build for C# projects needs to have any specific setup for C#. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
-| buildsetup_go | Indicates if the build for GO projects needs to have any specific setup for GO. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
-| buildsetup_javakotlin | Indicates if the build for Java/Kotlin projects needs to have any specific setup for Java. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
-| buildsetup_js | Indicates if the build for Javascript/Typescript projects needs to have any specific setup for JavaScript. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
-| buildsetup_python | Indicates if the build for Python projects needs to have any specific setup for Python. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
-| buildsetup_ruby | Indicates if the build for Ruby projects needs to have any specific setup for Ruby. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
-| buildsetup_swift | Indicates if the build for Swift projects needs to have any specific setup for Swift. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
+| buildsetup_cpp | Indicates if the build for CPP projects needs to have any specific setup for CPP. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | ""
+| buildsetup_csharp | Indicates if the build for C# projects needs to have any specific setup for C#, comma separated list. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | ""
+| buildsetup_go | Indicates if the build for GO projects needs to have any specific setup for GO, comma separated list. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | ""
+| buildsetup_javakotlin | Indicates if the build for Java/Kotlin projects needs to have any specific setup for Java, comma separated list. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | ""
+| buildsetup_js | Indicates if the build for Javascript/Typescript projects needs to have any specific setup for JavaScript, comma separated list. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | ""
+| buildsetup_python | Indicates if the build for Python projects needs to have any specific setup for Python, comma separated list. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | ""
+| buildsetup_ruby | Indicates if the build for Ruby projects needs to have any specific setup for Ruby, comma separated list. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | ""
+| buildsetup_swift | Indicates if the build for Swift projects needs to have any specific setup for Swift, comma separated list. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | ""
 
 ## ⬅️ Outputs
 | Name | Description |

--- a/README.md
+++ b/README.md
@@ -101,13 +101,21 @@ Various inputs are defined in [`action.yml`](action.yml):
 | envvars_ruby | Env vars in a JSON format with the variables that should be used for build | {} | 
 | envvars_swift | Env vars in a JSON format with the variables that should be used for build | {} |
 | skip_languages | The languages to skip when building the languages map, comma separated list. Useful if the test for a specific language is running on another tool | none |
+| buildsetup_cpp | Indicates if the build for CPP projects needs to have any specific setup for CPP. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
+| buildsetup_csharp | Indicates if the build for C# projects needs to have any specific setup for C#. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
+| buildsetup_go | Indicates if the build for GO projects needs to have any specific setup for GO. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
+| buildsetup_javakotlin | Indicates if the build for Java/Kotlin projects needs to have any specific setup for Java. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
+| buildsetup_js | Indicates if the build for Javascript/Typescript projects needs to have any specific setup for JavaScript. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
+| buildsetup_python | Indicates if the build for Python projects needs to have any specific setup for Python. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
+| buildsetup_ruby | Indicates if the build for Ruby projects needs to have any specific setup for Ruby. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
+| buildsetup_swift | Indicates if the build for Swift projects needs to have any specific setup for Swift. This is useful if you need to trigger for example a setup-language action before running the CodeQL Analysis | false
 
 ## ⬅️ Outputs
 | Name | Description |
 | --- | - |
 | languages_repo | The languages of the repository as an array |
 | languages_codeql | The languages of the repository as an array for CodeQL Matrix without Build Mode set |
-| languages_codeql_w_buildmode | The languages of the repository as a JSON array ([{language: string, build-mode: string, manual-build-command: [], vpn-connection: boolean, pre-commands: [], env-vars: {}}]) for CodeQL Matrix with Build Mode set |
+| languages_codeql_w_buildmode | The languages of the repository as a JSON array ([{language: string, build-mode: string, manual-build-command: [], vpn-connection: boolean, pre-commands: [], env-vars: {}, setup_language: boolean}]) for CodeQL Matrix with Build Mode set |
 | codeql_supported | Bool that indicates if there are supported languages by CodeQL |
 | skip_languages | The languages that were skipped when building the languages map
 

--- a/action.yml
+++ b/action.yml
@@ -161,42 +161,42 @@ inputs:
     description: Indicates if the build for C/C++ projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
-    type: boolean
+    type: string
   buildsetup_csharp:
     description: Indicates if the build for C# projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
-    type: boolean
+    type: string
   buildsetup_go:
     description: Indicates if the build for Go projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
-    type: boolean
+    type: string
   buildsetup_javakotlin:
     description: Indicates if the build for Java projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
-    type: boolean
+    type: string
   buildsetup_js:
     description: Indicates if the build for javascript-typescript projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
-    type: boolean
+    type: string
   buildsetup_python:
     description: Indicates if the build for Python projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
-    type: boolean
+    type: string
   buildsetup_ruby:
     description: Indicates if the build for Ruby projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
-    type: boolean
+    type: string
   buildsetup_swift:
     description: Indicates if the build for Swift projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
-    type: boolean
+    type: string
   
 outputs:
   languages_repo:

--- a/action.yml
+++ b/action.yml
@@ -157,7 +157,47 @@ inputs:
   skip_languages:
     description: The languages to skip when building the languages map, comma separated list
     required: false
-
+  buildsetup_cpp:
+    description: Indicates if the build for C/C++ projects needs to have an action to setup the language before running CodeQL'
+    default: false
+    required: false
+    type: boolean
+  build_setup_csharp:
+    description: Indicates if the build for C# projects needs to have an action to setup the language before running CodeQL'
+    default: false
+    required: false
+    type: boolean
+  build_setup_go:
+    description: Indicates if the build for Go projects needs to have an action to setup the language before running CodeQL'
+    default: false
+    required: false
+    type: boolean
+  build_setup_javakotlin:
+    description: Indicates if the build for Java projects needs to have an action to setup the language before running CodeQL'
+    default: false
+    required: false
+    type: boolean
+  build_setup_js:
+    description: Indicates if the build for javascript-typescript projects needs to have an action to setup the language before running CodeQL'
+    default: false
+    required: false
+    type: boolean
+  build_setup_python:
+    description: Indicates if the build for Python projects needs to have an action to setup the language before running CodeQL'
+    default: false
+    required: false
+    type: boolean
+  build_setup_ruby:
+    description: Indicates if the build for Ruby projects needs to have an action to setup the language before running CodeQL'
+    default: false
+    required: false
+    type: boolean
+  build_setup_swift:
+    description: Indicates if the build for Swift projects needs to have an action to setup the language before running CodeQL'
+    default: false
+    required: false
+    type: boolean
+  
 outputs:
   languages_repo:
     description: The languages of the repository as a JSON array

--- a/action.yml
+++ b/action.yml
@@ -162,37 +162,37 @@ inputs:
     default: false
     required: false
     type: boolean
-  build_setup_csharp:
+  buildsetup_csharp:
     description: Indicates if the build for C# projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
     type: boolean
-  build_setup_go:
+  buildsetup_go:
     description: Indicates if the build for Go projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
     type: boolean
-  build_setup_javakotlin:
+  buildsetup_javakotlin:
     description: Indicates if the build for Java projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
     type: boolean
-  build_setup_js:
+  buildsetup_js:
     description: Indicates if the build for javascript-typescript projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
     type: boolean
-  build_setup_python:
+  buildsetup_python:
     description: Indicates if the build for Python projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
     type: boolean
-  build_setup_ruby:
+  buildsetup_ruby:
     description: Indicates if the build for Ruby projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false
     type: boolean
-  build_setup_swift:
+  buildsetup_swift:
     description: Indicates if the build for Swift projects needs to have an action to setup the language before running CodeQL'
     default: false
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -30006,6 +30006,17 @@ async function run() {
             "ruby": core.getBooleanInput('buildvpn_ruby'),
             "swift": core.getBooleanInput('buildvpn_swift'),
         };
+        // Control variable to indicate to actions if a language needs a setup action before running the analysis
+        const buildSetup = {
+            "c-cpp": core.getBooleanInput('buildsetup_cpp'),
+            "csharp": core.getBooleanInput('buildsetup_csharp'),
+            "go": core.getBooleanInput('buildsetup_go'),
+            "java-kotlin": core.getBooleanInput('buildsetup_javakotlin'),
+            "javascript-typescript": core.getBooleanInput('buildsetup_js'),
+            "python": core.getBooleanInput('buildsetup_python'),
+            "ruby": core.getBooleanInput('buildsetup_ruby'),
+            "swift": core.getBooleanInput('buildsetup_swift'),
+        };
         // If there is an input for the module passing a custom build mode, store on this transitive const
         const customBuildmode = {
             "c-cpp": core.getInput('buildmode_cpp').toLowerCase(),
@@ -30023,7 +30034,7 @@ async function run() {
         if (skipLanguages.length > 0) {
             for (const lang of skipLanguages) {
                 if (!Object.keys(codeqlBuildmodeMapping).includes(lang)) {
-                    throw new Error(`Invalid language ${lang} in skip_languages input. Valid languages are ${Object.keys(codeqlLanguageMapping).join(', ')}`);
+                    throw new Error(`Invalid language ${lang} in skip_languages input. Valid languages are ${Object.keys(codeqlBuildmodeMapping).join(', ')}`);
                 }
             }
         }
@@ -30088,7 +30099,8 @@ async function run() {
             "manual-build-command": customManualBuildmodeCommand[language] || "",
             "vpn-connection": vpnConnection[language] || false,
             "pre-commands": preCommands[language] || [],
-            "env-vars": buildEnvVars[language] || {}
+            "env-vars": buildEnvVars[language] || {},
+            "build-setup": buildSetup[language] || false,
         }));
         core.setOutput('languages_repo', JSON.stringify(languages.map(l => l.toLowerCase())));
         core.setOutput('languages_codeql', JSON.stringify(languages_codeql_format));

--- a/dist/index.js
+++ b/dist/index.js
@@ -30006,17 +30006,6 @@ async function run() {
             "ruby": core.getBooleanInput('buildvpn_ruby'),
             "swift": core.getBooleanInput('buildvpn_swift'),
         };
-        // Control variable to indicate to actions if a language needs a setup action before running the analysis
-        const buildSetup = {
-            "c-cpp": core.getBooleanInput('buildsetup_cpp'),
-            "csharp": core.getBooleanInput('buildsetup_csharp'),
-            "go": core.getBooleanInput('buildsetup_go'),
-            "java-kotlin": core.getBooleanInput('buildsetup_javakotlin'),
-            "javascript-typescript": core.getBooleanInput('buildsetup_js'),
-            "python": core.getBooleanInput('buildsetup_python'),
-            "ruby": core.getBooleanInput('buildsetup_ruby'),
-            "swift": core.getBooleanInput('buildsetup_swift'),
-        };
         // If there is an input for the module passing a custom build mode, store on this transitive const
         const customBuildmode = {
             "c-cpp": core.getInput('buildmode_cpp').toLowerCase(),
@@ -30057,6 +30046,17 @@ async function run() {
             "python": core.getInput('buildmode_manual_python') ? core.getInput('buildmode_manual_python').split('\n').map(cmd => cmd.trim()) : [defaultBuildModeManualCommand],
             "ruby": core.getInput('buildmode_manual_ruby') ? core.getInput('buildmode_manual_ruby').split('\n').map(cmd => cmd.trim()) : [defaultBuildModeManualCommand],
             "swift": core.getInput('buildmode_manual_swift') ? core.getInput('buildmode_manual_swift').split('\n').map(cmd => cmd.trim()) : [defaultBuildModeManualCommand],
+        };
+        // Control variable to indicate to actions if a language needs a setup action before running the analysis
+        const buildSetup = {
+            "c-cpp": core.getInput('buildsetup_cpp') ? core.getInput('buildsetup_cpp').split(',').map(lang => lang.trim().toLowerCase()) : [],
+            "csharp": core.getInput('buildsetup_csharp') ? core.getInput('buildsetup_csharp').split(',').map(lang => lang.trim().toLowerCase()) : [],
+            "go": core.getInput('buildsetup_go') ? core.getInput('buildsetup_go').split(',').map(lang => lang.trim().toLowerCase()) : [],
+            "java-kotlin": core.getInput('buildsetup_javakotlin') ? core.getInput('buildsetup_javakotlin').split(',').map(lang => lang.trim().toLowerCase()) : [],
+            "javascript-typescript": core.getInput('buildsetup_js') ? core.getInput('buildsetup_js').split(',').map(lang => lang.trim().toLowerCase()) : [],
+            "python": core.getInput('buildsetup_python') ? core.getInput('buildsetup_python').split(',').map(lang => lang.trim().toLowerCase()) : [],
+            "ruby": core.getInput('buildsetup_ruby') ? core.getInput('buildsetup_ruby').split(',').map(lang => lang.trim().toLowerCase()) : [],
+            "swift": core.getInput('buildsetup_swift') ? core.getInput('buildsetup_swift').split(',').map(lang => lang.trim().toLowerCase()) : [],
         };
         // If there is a custom manual build mode command, update the default manual build mode command mapping
         let customManualBuildmodeCommand = {};
@@ -30100,7 +30100,7 @@ async function run() {
             "vpn-connection": vpnConnection[language] || false,
             "pre-commands": preCommands[language] || [],
             "env-vars": buildEnvVars[language] || {},
-            "build-setup": buildSetup[language] || false,
+            "build-setup": buildSetup[language] || [],
         }));
         core.setOutput('languages_repo', JSON.stringify(languages.map(l => l.toLowerCase())));
         core.setOutput('languages_codeql', JSON.stringify(languages_codeql_format));

--- a/src/run.ts
+++ b/src/run.ts
@@ -54,6 +54,18 @@ export async function run(): Promise<void> {
       "swift": core.getBooleanInput('buildvpn_swift'),
     }
 
+    // Control variable to indicate to actions if a language needs a setup action before running the analysis
+    const buildSetup : { [key: string]: boolean } = {
+      "c-cpp": core.getBooleanInput('buildsetup_cpp'),
+      "csharp": core.getBooleanInput('buildsetup_csharp'),
+      "go": core.getBooleanInput('buildsetup_go'),
+      "java-kotlin": core.getBooleanInput('buildsetup_javakotlin'),
+      "javascript-typescript": core.getBooleanInput('buildsetup_js'),
+      "python": core.getBooleanInput('buildsetup_python'),
+      "ruby": core.getBooleanInput('buildsetup_ruby'),
+      "swift": core.getBooleanInput('buildsetup_swift'),
+    }
+
     // If there is an input for the module passing a custom build mode, store on this transitive const
     const customBuildmode : { [key: string]: string } = {
       "c-cpp": core.getInput('buildmode_cpp').toLowerCase(),
@@ -149,7 +161,8 @@ export async function run(): Promise<void> {
       "manual-build-command": customManualBuildmodeCommand[language] || "",
       "vpn-connection": vpnConnection[language] || false,
       "pre-commands": preCommands[language] || [],
-      "env-vars": buildEnvVars[language] || {}
+      "env-vars": buildEnvVars[language] || {},
+      "build-setup": buildSetup[language] || false,
     }));
 
     core.setOutput('languages_repo', JSON.stringify(languages.map(l => l.toLowerCase())));

--- a/src/run.ts
+++ b/src/run.ts
@@ -54,18 +54,6 @@ export async function run(): Promise<void> {
       "swift": core.getBooleanInput('buildvpn_swift'),
     }
 
-    // Control variable to indicate to actions if a language needs a setup action before running the analysis
-    const buildSetup : { [key: string]: boolean } = {
-      "c-cpp": core.getBooleanInput('buildsetup_cpp'),
-      "csharp": core.getBooleanInput('buildsetup_csharp'),
-      "go": core.getBooleanInput('buildsetup_go'),
-      "java-kotlin": core.getBooleanInput('buildsetup_javakotlin'),
-      "javascript-typescript": core.getBooleanInput('buildsetup_js'),
-      "python": core.getBooleanInput('buildsetup_python'),
-      "ruby": core.getBooleanInput('buildsetup_ruby'),
-      "swift": core.getBooleanInput('buildsetup_swift'),
-    }
-
     // If there is an input for the module passing a custom build mode, store on this transitive const
     const customBuildmode : { [key: string]: string } = {
       "c-cpp": core.getInput('buildmode_cpp').toLowerCase(),
@@ -110,6 +98,18 @@ export async function run(): Promise<void> {
       "python": core.getInput('buildmode_manual_python') ? core.getInput('buildmode_manual_python').split('\n').map(cmd => cmd.trim()) : [defaultBuildModeManualCommand],
       "ruby": core.getInput('buildmode_manual_ruby') ? core.getInput('buildmode_manual_ruby').split('\n').map(cmd => cmd.trim()) : [defaultBuildModeManualCommand],
       "swift": core.getInput('buildmode_manual_swift') ? core.getInput('buildmode_manual_swift').split('\n').map(cmd => cmd.trim()) : [defaultBuildModeManualCommand],
+    }
+
+    // Control variable to indicate to actions if a language needs a setup action before running the analysis
+    const buildSetup : { [key: string]: string[] } = {
+      "c-cpp": core.getInput('buildsetup_cpp') ? core.getInput('buildsetup_cpp').split('\n').map(cmd => cmd.trim()) : [],
+      "csharp": core.getInput('buildsetup_csharp') ? core.getInput('buildsetup_csharp').split('\n').map(cmd => cmd.trim()) : [],
+      "go": core.getInput('buildsetup_go') ? core.getInput('buildsetup_go').split('\n').map(cmd => cmd.trim()) : [],
+      "java-kotlin": core.getInput('buildsetup_javakotlin') ? core.getInput('buildsetup_javakotlin').split('\n').map(cmd => cmd.trim()) : [],
+      "javascript-typescript": core.getInput('buildsetup_js') ? core.getInput('buildsetup_js').split('\n').map(cmd => cmd.trim()) : [],
+      "python": core.getInput('buildsetup_python') ? core.getInput('buildsetup_python').split('\n').map(cmd => cmd.trim()) : [],
+      "ruby": core.getInput('buildsetup_ruby') ? core.getInput('buildsetup_ruby').split('\n').map(cmd => cmd.trim()) : [],
+      "swift": core.getInput('buildsetup_swift') ? core.getInput('buildsetup_swift').split('\n').map(cmd => cmd.trim()) : [],
     }
 
     // If there is a custom manual build mode command, update the default manual build mode command mapping
@@ -162,7 +162,7 @@ export async function run(): Promise<void> {
       "vpn-connection": vpnConnection[language] || false,
       "pre-commands": preCommands[language] || [],
       "env-vars": buildEnvVars[language] || {},
-      "build-setup": buildSetup[language] || false,
+      "build-setup": buildSetup[language] || [],
     }));
 
     core.setOutput('languages_repo', JSON.stringify(languages.map(l => l.toLowerCase())));

--- a/src/run.ts
+++ b/src/run.ts
@@ -102,14 +102,14 @@ export async function run(): Promise<void> {
 
     // Control variable to indicate to actions if a language needs a setup action before running the analysis
     const buildSetup : { [key: string]: string[] } = {
-      "c-cpp": core.getInput('buildsetup_cpp') ? core.getInput('buildsetup_cpp').split('\n').map(cmd => cmd.trim()) : [],
-      "csharp": core.getInput('buildsetup_csharp') ? core.getInput('buildsetup_csharp').split('\n').map(cmd => cmd.trim()) : [],
-      "go": core.getInput('buildsetup_go') ? core.getInput('buildsetup_go').split('\n').map(cmd => cmd.trim()) : [],
-      "java-kotlin": core.getInput('buildsetup_javakotlin') ? core.getInput('buildsetup_javakotlin').split('\n').map(cmd => cmd.trim()) : [],
-      "javascript-typescript": core.getInput('buildsetup_js') ? core.getInput('buildsetup_js').split('\n').map(cmd => cmd.trim()) : [],
-      "python": core.getInput('buildsetup_python') ? core.getInput('buildsetup_python').split('\n').map(cmd => cmd.trim()) : [],
-      "ruby": core.getInput('buildsetup_ruby') ? core.getInput('buildsetup_ruby').split('\n').map(cmd => cmd.trim()) : [],
-      "swift": core.getInput('buildsetup_swift') ? core.getInput('buildsetup_swift').split('\n').map(cmd => cmd.trim()) : [],
+      "c-cpp": core.getInput('buildsetup_cpp') ? core.getInput('buildsetup_cpp').split(',').map(lang => lang.trim().toLowerCase()) : [],
+      "csharp": core.getInput('buildsetup_csharp') ? core.getInput('buildsetup_csharp').split(',').map(lang => lang.trim().toLowerCase()) : [],
+      "go": core.getInput('buildsetup_go') ? core.getInput('buildsetup_go').split(',').map(lang => lang.trim().toLowerCase()) : [],
+      "java-kotlin": core.getInput('buildsetup_javakotlin') ? core.getInput('buildsetup_javakotlin').split(',').map(lang => lang.trim().toLowerCase()) : [],
+      "javascript-typescript": core.getInput('buildsetup_js') ? core.getInput('buildsetup_js').split(',').map(lang => lang.trim().toLowerCase()) : [],
+      "python": core.getInput('buildsetup_python') ? core.getInput('buildsetup_python').split(',').map(lang => lang.trim().toLowerCase()) : [],
+      "ruby": core.getInput('buildsetup_ruby') ? core.getInput('buildsetup_ruby').split(',').map(lang => lang.trim().toLowerCase()) : [],
+      "swift": core.getInput('buildsetup_swift') ? core.getInput('buildsetup_swift').split(',').map(lang => lang.trim().toLowerCase()) : [],
     }
 
     // If there is a custom manual build mode command, update the default manual build mode command mapping


### PR DESCRIPTION
This allows to set a boolean false/true for each language to be added to the matrix.
This helps if you need to for example run a setup-language action before running codeql.

Example:

```
  codeql_scan:
    needs: codeql_pretasks
    if: ${{ inputs.codeql_enabled == true }}
    name: Analyze Code with CodeQL
    runs-on: ${{ (matrix.language == 'swift' && inputs.codeql_swift_runner) || 'ubuntu-latest' }}
    strategy:
      fail-fast: false
      matrix:
        include: ${{ fromJSON(needs.codeql_pretasks.outputs.languages_codeql_w_buildmode) }}
    steps:
      - name: Install Java JDK
        if: matrix.build-setup == true
        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
        with:
          distribution: ${{ inputs.java_distribution}}
          java-version: ${{ inputs.java_version}}
      - name: Install Ruby
        if: matrix.build-setup == true
        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
        with:
          ruby-version: ${{ inputs.ruby_version}}
          bundler-cache: true
      - name: Checkout Repo for CodeQL analysis
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
        with:
          fetch-depth: 0
...
```