### PR TITLE
feat: add GitHub Actions workflow scanning (actions language) + upgrade to Node 24

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm install

--- a/action.yml
+++ b/action.yml
@@ -211,5 +211,5 @@ outputs:
     description: The languages that were skipped when building the languages map
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -29983,6 +29983,10 @@ async function run() {
             "python": "python",
             "ruby": "ruby",
             "swift": "swift",
+            // `actions` is a pseudo-language: Linguist/GitHub does not report it in
+            // the /languages endpoint. It is detected separately below by looking
+            // for workflow YAML files in .github/workflows/.
+            "actions": "actions",
         };
         // Mapping between the CodeQL languages and the default build mode for CodeQL
         let codeqlBuildmodeMapping = {
@@ -29994,6 +29998,8 @@ async function run() {
             "python": "none",
             "ruby": "none",
             "swift": "none",
+            // `actions` scans workflow YAML files — no compilation needed.
+            "actions": "none",
         };
         // Control variable to indicate to actions if a VPN Connection needs to be established for the analysis
         const vpnConnection = {
@@ -30090,6 +30096,24 @@ async function run() {
         const langResponse = await octokit.request(`GET /repos/${owner}/${repo}/languages`);
         core.debug(JSON.stringify({ langResponse }));
         let languages = Object.keys(langResponse.data);
+        // Detect GitHub Actions workflows manually — the /languages endpoint
+        // (Linguist) does not classify workflow YAML as the CodeQL `actions`
+        // language. If the repo has any .yml / .yaml files under .github/workflows,
+        // we inject the pseudo-language `actions` into the matrix so CodeQL can
+        // scan the workflow files themselves (the same coverage GitHub's default
+        // setup provides via `languages: ["actions"]`).
+        try {
+            const workflowDir = await octokit.rest.repos.getContent({ owner, repo, path: '.github/workflows' });
+            if (Array.isArray(workflowDir.data)) {
+                const hasWorkflowYaml = workflowDir.data.some(f => f.type === 'file' && /\.ya?ml$/i.test(f.name));
+                if (hasWorkflowYaml) {
+                    languages.push('actions');
+                }
+            }
+        }
+        catch {
+            // No .github/workflows directory (or inaccessible) — skip actions scanning
+        }
         let languages_codeql_format = Array.from(new Set(languages
             .map(l => codeqlLanguageMapping[l.toLowerCase()])
             .filter(l => l && !skipLanguages.includes(l))));

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@github/local-action": "github:github/local-action",
-        "@types/node": "^22.13.1",
+        "@types/node": "^24.12.2",
         "@typescript-eslint/eslint-plugin": "^8.24.0",
         "@typescript-eslint/parser": "^8.24.0",
         "@vercel/ncc": "^0.38.3",
@@ -3020,13 +3020,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
-      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -8835,9 +8835,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@github/local-action": "github:github/local-action",
-    "@types/node": "^22.13.1",
+    "@types/node": "^24.12.2",
     "@typescript-eslint/eslint-plugin": "^8.24.0",
     "@typescript-eslint/parser": "^8.24.0",
     "@vercel/ncc": "^0.38.3",

--- a/src/run.ts
+++ b/src/run.ts
@@ -28,6 +28,10 @@ export async function run(): Promise<void> {
       "python": "python",
       "ruby": "ruby",
       "swift": "swift",
+      // `actions` is a pseudo-language: Linguist/GitHub does not report it in
+      // the /languages endpoint. It is detected separately below by looking
+      // for workflow YAML files in .github/workflows/.
+      "actions": "actions",
     }
 
     // Mapping between the CodeQL languages and the default build mode for CodeQL
@@ -40,6 +44,8 @@ export async function run(): Promise<void> {
       "python": "none",
       "ruby": "none",
       "swift": "none",
+      // `actions` scans workflow YAML files — no compilation needed.
+      "actions": "none",
     }
 
     // Control variable to indicate to actions if a VPN Connection needs to be established for the analysis
@@ -147,6 +153,27 @@ export async function run(): Promise<void> {
     const langResponse = await octokit.request(`GET /repos/${owner}/${repo}/languages`);
     core.debug(JSON.stringify({langResponse}))
     let languages: string[] = Object.keys(langResponse.data);
+
+    // Detect GitHub Actions workflows manually — the /languages endpoint
+    // (Linguist) does not classify workflow YAML as the CodeQL `actions`
+    // language. If the repo has any .yml / .yaml files under .github/workflows,
+    // we inject the pseudo-language `actions` into the matrix so CodeQL can
+    // scan the workflow files themselves (the same coverage GitHub's default
+    // setup provides via `languages: ["actions"]`).
+    try {
+      const workflowDir = await octokit.rest.repos.getContent({ owner, repo, path: '.github/workflows' });
+      if (Array.isArray(workflowDir.data)) {
+        const hasWorkflowYaml = workflowDir.data.some(
+          f => f.type === 'file' && /\.ya?ml$/i.test(f.name)
+        );
+        if (hasWorkflowYaml) {
+          languages.push('actions');
+        }
+      }
+    } catch {
+      // No .github/workflows directory (or inaccessible) — skip actions scanning
+    }
+
     let languages_codeql_format = Array.from(
       new Set(
         languages


### PR DESCRIPTION
## Summary

Two changes bundled in this release:

1. **Add `actions` pseudo-language detection** — detects `.github/workflows/*.{yml,yaml}` files and injects `actions` into the CodeQL matrix output with `build-mode: none`. Restores code scanning coverage of workflow files for repos using custom/advanced CodeQL setup.

2. **Upgrade runtime from Node 20 to Node 24** — `action.yml` `using: "node24"`, CI `setup-node: 24`, `@types/node: ^24.12.2`. Addresses GitHub's deprecation of Node 20 for actions (2025-09), hard removal 2026-09.

## Actions language support

CodeQL supports scanning GitHub Actions workflow files as a distinct `actions` language since mid-2024. But the GitHub `/repos/{owner}/{repo}/languages` endpoint (backed by Linguist) does not report `actions` — workflow YAMLs show up only as generic YAML and are filtered out.

### Implementation in src/run.ts

1. Add `actions` to the CodeQL mappings:
   ```typescript
   codeqlLanguageMapping: { ..., "actions": "actions" }
   codeqlBuildmodeMapping: { ..., "actions": "none" }
   ```
2. After fetching `/languages`, detect workflow YAMLs manually:
   ```typescript
   try {
     const workflowDir = await octokit.rest.repos.getContent({
       owner, repo, path: '.github/workflows'
     });
     if (Array.isArray(workflowDir.data)) {
       const hasWorkflowYaml = workflowDir.data.some(
         f => f.type === 'file' && /\.ya?ml$/i.test(f.name)
       );
       if (hasWorkflowYaml) {
         languages.push('actions');
       }
     }
   } catch { /* no .github/workflows — skip */ }
   ```

If the repo has no `.github/workflows/` directory, nothing is added. If it has workflow YAMLs, the output matrix gains an entry with `language: actions`, `build-mode: none`, and empty defaults for the other fields.

## Node 24 upgrade

- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- Node 20 deprecated for actions (2025-09)
- Removed from runners (2026-09, hard cutoff)

`dist/index.js` is byte-identical between Node 20 and Node 24 builds — ncc bundles JavaScript at build time, runtime version only affects which Node binary executes the bundle. Rebuilding in `node:24` Docker produced the exact same output.

## Breaking changes

None functionally. Consumers whose repos have `.github/workflows/*.yaml` will see one new short-running CodeQL job per run — the desired outcome (restores coverage previously provided by GitHub default setup).

## Suggested release

**v3.1.0** (minor bump) — new pseudo-language support + Node 24 runtime.