### PR TITLE
feat: map html to javascript-typescript for CodeQL

### DIFF
--- a/__tests__/mapping.test.ts
+++ b/__tests__/mapping.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, jest, test, beforeEach } from '@jest/globals';
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+
+jest.mock('@actions/core');
+jest.mock('@actions/github');
+
+const mockedCore = core as jest.Mocked<typeof core>;
+const mockedGithub = github as jest.Mocked<typeof github>;
+
+/**
+ * Builds a mocked octokit that returns the given /languages payload and
+ * reports no .github/workflows directory.
+ */
+function mockOctokit(languagesData: { [lang: string]: number }) {
+  const request = jest.fn(async () => ({ data: languagesData }));
+  const getContent = jest.fn(async () => {
+    throw new Error('Not Found');
+  });
+  return {
+    request,
+    rest: { repos: { getContent } },
+  } as unknown as ReturnType<typeof github.getOctokit>;
+}
+
+describe('codeqlLanguageMapping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // All getInput / getBooleanInput calls return empty/false by default.
+    mockedCore.getInput.mockImplementation((name: string) => {
+      if (name === 'github_token') return 'fake-token';
+      if (name === 'owner') return 'acme';
+      if (name === 'repo') return 'static-site';
+      return '';
+    });
+    mockedCore.getBooleanInput.mockReturnValue(false);
+  });
+
+  test('maps HTML to javascript-typescript', async () => {
+    mockedGithub.getOctokit.mockReturnValue(mockOctokit({ HTML: 1000 }));
+
+    const { run } = await import('../src/run');
+    await run();
+
+    const codeqlOutput = mockedCore.setOutput.mock.calls.find(
+      ([name]) => name === 'languages_codeql'
+    );
+    expect(codeqlOutput).toBeDefined();
+    expect(JSON.parse(codeqlOutput![1] as string)).toContain('javascript-typescript');
+
+    const supported = mockedCore.setOutput.mock.calls.find(
+      ([name]) => name === 'codeql_supported'
+    );
+    expect(JSON.parse(supported![1] as string)).toBe(true);
+  });
+
+  test('a pure-HTML repo is CodeQL-supported via the html mapping', async () => {
+    mockedGithub.getOctokit.mockReturnValue(mockOctokit({ HTML: 500, CSS: 50 }));
+
+    const { run } = await import('../src/run');
+    await run();
+
+    const codeqlOutput = mockedCore.setOutput.mock.calls.find(
+      ([name]) => name === 'languages_codeql'
+    );
+    // CSS has no CodeQL language and is dropped; HTML yields javascript-typescript.
+    expect(JSON.parse(codeqlOutput![1] as string)).toEqual(['javascript-typescript']);
+  });
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -35369,6 +35369,11 @@ async function run() {
             "kotlin": "java-kotlin",
             "javascript": "javascript-typescript",
             "typescript": "javascript-typescript",
+            // HTML has no standalone CodeQL language — the javascript-typescript
+            // extractor processes .html/.htm/.xhtml/.vue/.hbs/.json/.yaml alongside
+            // .js/.ts. Mapping html here lets pure-HTML repos (static-asset apps
+            // with no .js) trigger CodeQL analysis of their markup.
+            "html": "javascript-typescript",
             "python": "python",
             "ruby": "ruby",
             "swift": "swift",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-typescript",
-  "version": "1.2.0",
+  "version": "3.2.0",
   "description": "GitHub Actions TypeScript template",
   "main": "dist/index.js",
   "scripts": {

--- a/src/run.ts
+++ b/src/run.ts
@@ -25,6 +25,11 @@ export async function run(): Promise<void> {
       "kotlin": "java-kotlin",
       "javascript": "javascript-typescript",
       "typescript": "javascript-typescript",
+      // HTML has no standalone CodeQL language — the javascript-typescript
+      // extractor processes .html/.htm/.xhtml/.vue/.hbs/.json/.yaml alongside
+      // .js/.ts. Mapping html here lets pure-HTML repos (static-asset apps
+      // with no .js) trigger CodeQL analysis of their markup.
+      "html": "javascript-typescript",
       "python": "python",
       "ruby": "ruby",
       "swift": "swift",


### PR DESCRIPTION
## Summary

Repos with HTML but no `.js` (static-asset apps) were detected as having no CodeQL-supported language — GitHub Linguist reports `HTML`, which had no entry in `codeqlLanguageMapping`. CodeQL's `javascript-typescript` extractor processes `.html/.htm/.xhtml/.vue/.hbs` alongside `.js/.ts`, so mapping `html → javascript-typescript` gives pure-HTML repos real CodeQL coverage instead of falling through to actions-only.

- `src/run.ts`: +`html` entry in `codeqlLanguageMapping`
- `dist/index.js`: rebuilt (`ncc build`)
- `__tests__/mapping.test.ts`: new focused tests for the html mapping
- `package.json`: version 3.2.0